### PR TITLE
chore(release): setup automated semantic versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,29 @@ jobs:
 
       - name: Check formatting
         run: make fmt-check
+
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ lint, test, format-check ]
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.0'
+
+      - name: Run Semantic Release
+        uses: go-semantic-release/action@v1
+        with:
+          changelog-file: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.semrelrc
+++ b/.semrelrc
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "commit-analyzer": {
+      "name": "default"
+    },
+    "changelog-generator": {
+      "name": "default"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,12 @@ Refs: OTC-X
 - E2E tests: `test/e2e/`
 
 Use table-driven tests. See `pkg/otc/version_test.go` for example.
+
+## Releases
+
+Releases are automated via semantic versioning:
+- Merges to `main` trigger automatic version detection
+- Version determined by commit types (feat/fix/BREAKING CHANGE)
+- Tags, changelog, and GitHub releases created automatically
+
+No manual versioning needed.


### PR DESCRIPTION
## Changes
- **Automated Versioning**: Configured go-semantic-release for automatic version management
- **Changelog**: Added CHANGELOG.md following Keep a Changelog format
- **CI Integration**: Added release job to GitHub Actions workflow
  - Triggers on merges to main
  - Analyzes conventional commits
  - Creates git tags and GitHub releases automatically
- **Configuration**: Added .semrelrc for semantic-release plugin settings
- **Documentation**: Updated CONTRIBUTING.md with release process explanation

## Verification
- [x] CHANGELOG.md created with proper format
- [x] .semrelrc configuration added
- [x] Release job added to CI workflow
- [x] CONTRIBUTING.md updated
- [ ] Release automation tested on main merge

## How It Works
- **feat:** commits → minor version bump (0.1.0 → 0.2.0)
- **fix:** commits → patch version bump (0.1.0 → 0.1.1)
- **BREAKING CHANGE:** → major version bump (0.1.0 → 1.0.0)

When merged to main, semantic-release will:
1. Analyze commit history
2. Determine next version
3. Update CHANGELOG.md
4. Create git tag
5. Publish GitHub release

Closes: OTC-6