### PR TITLE
feat(runtime): add OTC_RUNTIME environment variable override

### DIFF
--- a/pkg/otc/runtime/override_test.go
+++ b/pkg/otc/runtime/override_test.go
@@ -1,0 +1,241 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestGetOverrideFromEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		envValue string
+		want     string
+	}{
+		{
+			name:     "not set",
+			envValue: "",
+			want:     "",
+		},
+		{
+			name:     "runc",
+			envValue: "runc",
+			want:     "runc",
+		},
+		{
+			name:     "with whitespace",
+			envValue: "  runc  ",
+			want:     "runc",
+		},
+		{
+			name:     "containerd",
+			envValue: "containerd",
+			want:     "containerd",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Can't run parallel here because we're modifying env
+
+			// Set env var
+			if tt.envValue != "" {
+				if err := os.Setenv("OTC_RUNTIME", tt.envValue); err != nil {
+					t.Fatalf("failed to set OTC_RUNTIME: %v", err)
+				}
+			} else {
+				if err := os.Unsetenv("OTC_RUNTIME"); err != nil {
+					t.Fatalf("failed to unset OTC_RUNTIME: %v", err)
+				}
+			}
+			defer func() {
+				if err := os.Unsetenv("OTC_RUNTIME"); err != nil {
+					t.Errorf("failed to cleanup OTC_RUNTIME: %v", err)
+				}
+			}()
+
+			got := getOverrideFromEnv()
+			if got != tt.want {
+				t.Errorf("getOverrideFromEnv() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetector_Detect_WithOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		override  string
+		oci       OCIDetector
+		cri       CRIDetector
+		podman    PodmanDetector
+		wantErr   bool
+		errMsg    string
+		checkFunc func(t *testing.T, result *Result)
+	}{
+		{
+			name:     "override runc - found",
+			override: "runc",
+			oci:      NewOCIDetector(),
+			cri:      nil,
+			podman:   nil,
+			wantErr:  false,
+			checkFunc: func(t *testing.T, result *Result) {
+				if result == nil {
+					t.Fatal("expected result, got nil")
+				}
+				// We can't guarantee runc is installed, but if result
+				// is returned, it should have the right structure
+				if len(result.Runtimes) > 0 {
+					if result.Runtimes[0].Name != "runc" {
+						t.Errorf("expected runc, got %s", result.Runtimes[0].Name)
+					}
+					if result.Selected == nil {
+						t.Error("expected Selected to be set")
+					}
+					if result.Selected.Name != "runc" {
+						t.Errorf("expected Selected to be runc, got %s", result.Selected.Name)
+					}
+				}
+			},
+		},
+		{
+			name:     "override invalid runtime name",
+			override: "invalid-runtime",
+			oci:      NewOCIDetector(),
+			cri:      nil,
+			podman:   nil,
+			wantErr:  true,
+			errMsg:   "invalid OTC_RUNTIME value",
+		},
+		{
+			name:     "override containerd - detector not configured",
+			override: "containerd",
+			oci:      NewOCIDetector(),
+			cri:      nil, // CRI detector not provided
+			podman:   nil,
+			wantErr:  true,
+			errMsg:   "CRI detector not configured",
+		},
+		{
+			name:     "override podman - detector not configured",
+			override: "podman",
+			oci:      NewOCIDetector(),
+			cri:      nil,
+			podman:   nil, // Podman detector not provided
+			wantErr:  true,
+			errMsg:   "Podman detector not configured",
+		},
+		{
+			name:     "override docker - not supported",
+			override: "docker",
+			oci:      NewOCIDetector(),
+			cri:      nil,
+			podman:   nil,
+			wantErr:  true,
+			errMsg:   "Docker runtime not yet supported",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create detector with override
+			detector := &Detector{
+				oci:      tt.oci,
+				cri:      tt.cri,
+				podman:   tt.podman,
+				override: tt.override,
+			}
+
+			result, err := detector.Detect(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.errMsg != "" {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if !contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			}
+
+			if !tt.wantErr && tt.checkFunc != nil {
+				tt.checkFunc(t, result)
+			}
+		})
+	}
+}
+
+func TestDetector_Detect_WithoutOverride(t *testing.T) {
+	t.Parallel()
+
+	// Test that normal detection still works when no override is set
+	detector := &Detector{
+		oci:      NewOCIDetector(),
+		cri:      nil,
+		podman:   nil,
+		override: "", // No override
+	}
+
+	result, err := detector.Detect(context.Background())
+	if err != nil {
+		// It's OK if no runtimes found, just shouldn't panic
+		return
+	}
+
+	// If runtimes found, they should be from OCI detector only
+	for _, rt := range result.Runtimes {
+		if rt.Type != TypeOCI {
+			t.Errorf("expected TypeOCI, got %v", rt.Type)
+		}
+	}
+}
+
+func TestNewDetector_ReadsEnv(t *testing.T) {
+	// This test modifies env, so can't run parallel
+
+	// Set environment variable
+	if err := os.Setenv("OTC_RUNTIME", "runc"); err != nil {
+		t.Fatalf("failed to set OTC_RUNTIME: %v", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("OTC_RUNTIME"); err != nil {
+			t.Errorf("failed to cleanup OTC_RUNTIME: %v", err)
+		}
+	}()
+
+	detector := NewDetector(NewOCIDetector(), nil, nil)
+
+	// Check that detector has override set
+	if detector.override != "runc" {
+		t.Errorf("expected override to be 'runc', got %q", detector.override)
+	}
+}
+
+// contains checks if string s contains substring substr.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		(s == substr || len(substr) == 0 ||
+			(len(s) > len(substr) && indexString(s, substr) >= 0))
+}
+
+// indexString returns the index of substr in s, or -1 if not found.
+func indexString(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/otc/runtime/override_test.go
+++ b/pkg/otc/runtime/override_test.go
@@ -20,14 +20,14 @@ func TestGetOverrideFromEnv(t *testing.T) {
 			want:     "",
 		},
 		{
-			name:     "runc",
-			envValue: "runc",
-			want:     "runc",
+			name:     Runc,
+			envValue: Runc,
+			want:     Runc,
 		},
 		{
 			name:     "with whitespace",
 			envValue: "  runc  ",
-			want:     "runc",
+			want:     Runc,
 		},
 		{
 			name:     "containerd",
@@ -80,7 +80,7 @@ func TestDetector_Detect_WithOverride(t *testing.T) {
 	}{
 		{
 			name:     "override runc - found",
-			override: "runc",
+			override: Runc,
 			oci:      NewOCIDetector(),
 			cri:      nil,
 			podman:   nil,
@@ -92,13 +92,13 @@ func TestDetector_Detect_WithOverride(t *testing.T) {
 				// We can't guarantee runc is installed, but if result
 				// is returned, it should have the right structure
 				if len(result.Runtimes) > 0 {
-					if result.Runtimes[0].Name != "runc" {
+					if result.Runtimes[0].Name != Runc {
 						t.Errorf("expected runc, got %s", result.Runtimes[0].Name)
 					}
 					if result.Selected == nil {
 						t.Error("expected Selected to be set")
 					}
-					if result.Selected.Name != "runc" {
+					if result.Selected.Name != Runc {
 						t.Errorf("expected Selected to be runc, got %s", result.Selected.Name)
 					}
 				}
@@ -138,7 +138,7 @@ func TestDetector_Detect_WithOverride(t *testing.T) {
 			cri:      nil,
 			podman:   nil,
 			wantErr:  true,
-			errMsg:   "Docker runtime not yet supported",
+			errMsg:   "docker runtime not yet supported",
 		},
 	}
 
@@ -206,7 +206,7 @@ func TestNewDetector_ReadsEnv(t *testing.T) {
 	// This test modifies env, so can't run parallel
 
 	// Set environment variable
-	if err := os.Setenv("OTC_RUNTIME", "runc"); err != nil {
+	if err := os.Setenv("OTC_RUNTIME", Runc); err != nil {
 		t.Fatalf("failed to set OTC_RUNTIME: %v", err)
 	}
 	defer func() {
@@ -218,7 +218,7 @@ func TestNewDetector_ReadsEnv(t *testing.T) {
 	detector := NewDetector(NewOCIDetector(), nil, nil)
 
 	// Check that detector has override set
-	if detector.override != "runc" {
+	if detector.override != Runc {
 		t.Errorf("expected override to be 'runc', got %q", detector.override)
 	}
 }

--- a/pkg/otc/runtime/types.go
+++ b/pkg/otc/runtime/types.go
@@ -56,13 +56,13 @@ const (
 
 // Runtime name constants for OTC_RUNTIME environment variable.
 const (
-	RNRunc       = "runc"
-	RNCrun       = "crun"
-	RNYouki      = "youki"
-	RNContainerd = "containerd"
-	RNCRIO       = "crio"
-	RNPodman     = "podman"
-	RNDocker     = "docker"
+	Runc       = "runc"
+	Crun       = "crun"
+	Youki      = "youki"
+	Containerd = "containerd"
+	CRIO       = "crio"
+	Podman     = "podman"
+	Docker     = "docker"
 )
 
 // Result contains the results of runtime detection.
@@ -203,25 +203,25 @@ func (d *Detector) detectOverride(ctx context.Context) (*Result, error) {
 
 	// Determine which detector to use based on override value
 	switch d.override {
-	case RNRunc, RNCrun, RNYouki:
+	case Runc, Crun, Youki:
 		if d.oci == nil {
 			return nil, fmt.Errorf("OTC_RUNTIME=%s but OCI detector not configured", d.override)
 		}
 		runtimes, err = d.oci.Detect()
 
-	case RNContainerd, RNCRIO:
+	case Containerd, CRIO:
 		if d.cri == nil {
 			return nil, fmt.Errorf("OTC_RUNTIME=%s but CRI detector not configured", d.override)
 		}
 		runtimes, err = d.cri.Detect(ctx)
 
-	case RNPodman:
+	case Podman:
 		if d.podman == nil {
 			return nil, fmt.Errorf("OTC_RUNTIME=%s but Podman detector not configured", d.override)
 		}
 		runtimes, err = d.podman.Detect(ctx)
 
-	case RNDocker:
+	case Docker:
 		return nil, fmt.Errorf("docker runtime not yet supported")
 
 	default:

--- a/pkg/otc/runtime/types.go
+++ b/pkg/otc/runtime/types.go
@@ -3,6 +3,9 @@ package runtime
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 )
 
 // Type represents the category of container runtime.
@@ -51,6 +54,17 @@ const (
 	PriorityDocker = 30  // Docker (backward compatibility)
 )
 
+// Runtime name constants for OTC_RUNTIME environment variable.
+const (
+	RNRunc       = "runc"
+	RNCrun       = "crun"
+	RNYouki      = "youki"
+	RNContainerd = "containerd"
+	RNCRIO       = "crio"
+	RNPodman     = "podman"
+	RNDocker     = "docker"
+)
+
 // Result contains the results of runtime detection.
 type Result struct {
 	// Runtimes is the list of all detected runtimes, ordered by priority (highest first)
@@ -94,18 +108,24 @@ type PodmanDetector interface {
 
 // Detector orchestrates runtime detection across all types.
 type Detector struct {
-	oci    OCIDetector
-	cri    CRIDetector
-	podman PodmanDetector
+	oci      OCIDetector
+	cri      CRIDetector
+	podman   PodmanDetector
+	override string // If set, only detect this specific runtime
 }
 
 // NewDetector creates a new runtime detector with the provided implementations.
 // Pass nil for any detector type not needed.
+//
+// The detector automatically reads the OTC_RUNTIME environment variable.
+// If set, only the specified runtime will be detected.
+// Valid values: runc, crun, youki, containerd, crio, podman, docker
 func NewDetector(oci OCIDetector, cri CRIDetector, podman PodmanDetector) *Detector {
 	return &Detector{
-		oci:    oci,
-		cri:    cri,
-		podman: podman,
+		oci:      oci,
+		cri:      cri,
+		podman:   podman,
+		override: getOverrideFromEnv(),
 	}
 }
 
@@ -113,7 +133,15 @@ func NewDetector(oci OCIDetector, cri CRIDetector, podman PodmanDetector) *Detec
 // It aggregates results from all configured detectors and selects the highest priority runtime.
 // If individual detectors fail, detection continues and errors are returned in Result.Warnings.
 // Only returns error if all detectors fail or a fatal error occurs.
+//
+// If OTC_RUNTIME environment variable is set, only the specified runtime is detected.
+// Returns error if the specified runtime is not found.
 func (d *Detector) Detect(ctx context.Context) (*Result, error) {
+	// If override is set, only detect that runtime
+	if d.override != "" {
+		return d.detectOverride(ctx)
+	}
+
 	var runtimes []Runtime
 	var warnings []error
 
@@ -147,7 +175,7 @@ func (d *Detector) Detect(ctx context.Context) (*Result, error) {
 		}
 	}
 
-	// If no runtimes found, and we have warnings, return the first error
+	// If no runtimes found and we have warnings, return the first error
 	if len(runtimes) == 0 && len(warnings) > 0 {
 		return nil, warnings[0]
 	}
@@ -166,4 +194,66 @@ func (d *Detector) Detect(ctx context.Context) (*Result, error) {
 	}
 
 	return result, nil
+}
+
+// detectOverride detects only the runtime specified in OTC_RUNTIME.
+func (d *Detector) detectOverride(ctx context.Context) (*Result, error) {
+	var runtimes []Runtime
+	var err error
+
+	// Determine which detector to use based on override value
+	switch d.override {
+	case RNRunc, RNCrun, RNYouki:
+		if d.oci == nil {
+			return nil, fmt.Errorf("OTC_RUNTIME=%s but OCI detector not configured", d.override)
+		}
+		runtimes, err = d.oci.Detect()
+
+	case RNContainerd, RNCRIO:
+		if d.cri == nil {
+			return nil, fmt.Errorf("OTC_RUNTIME=%s but CRI detector not configured", d.override)
+		}
+		runtimes, err = d.cri.Detect(ctx)
+
+	case RNPodman:
+		if d.podman == nil {
+			return nil, fmt.Errorf("OTC_RUNTIME=%s but Podman detector not configured", d.override)
+		}
+		runtimes, err = d.podman.Detect(ctx)
+
+	case RNDocker:
+		return nil, fmt.Errorf("docker runtime not yet supported")
+
+	default:
+		return nil, fmt.Errorf("invalid OTC_RUNTIME value: %s (valid: runc, crun, youki, containerd, crio, podman)", d.override)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect runtime %s: %w", d.override, err)
+	}
+
+	// Filter to only the requested runtime
+	var filtered []Runtime
+	for _, rt := range runtimes {
+		if rt.Name == d.override {
+			filtered = append(filtered, rt)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("runtime %s not found on system", d.override)
+	}
+
+	result := &Result{
+		Runtimes: filtered,
+		Selected: &filtered[0],
+	}
+
+	return result, nil
+}
+
+// getOverrideFromEnv reads the OTC_RUNTIME environment variable.
+// Returns empty string if not set or if value is empty after trimming whitespace.
+func getOverrideFromEnv() string {
+	return strings.TrimSpace(os.Getenv("OTC_RUNTIME"))
 }


### PR DESCRIPTION
## Summary
Implements OTC_RUNTIME environment variable override for runtime selection.

## Changes
- ✅ Add runtime name constants (Runc, Crun, Youki, Containerd, CRIO, Podman)
- ✅ Add override field to Detector struct
- ✅ Implement getOverrideFromEnv() for env var reading
- ✅ Implement detectOverride() for filtered detection
- ✅ Update Detect() to handle override path
- ✅ Add comprehensive tests for override behavior
- ✅ Update cmd/detect example to show override in action

## Architecture
- Environment variable read once in NewDetector()
- Override detection uses switch statement grouped by detector type
- Clear error messages for invalid/missing runtimes
- Whitespace trimming for user convenience

## Testing
```bash
# Unit tests
go test -v ./pkg/otc/runtime/ -run Override
go test -race ./pkg/otc/runtime/
make check

# Manual testing
go run cmd/detect/main.go
OTC_RUNTIME=runc go run cmd/detect/main.go
OTC_RUNTIME=invalid go run cmd/detect/main.go